### PR TITLE
Bump OTP version in .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,5 +6,5 @@
 #
 # The versions selected here are the versions that are used to build a binary
 # release for distribution
-elixir 1.7.4-otp-21
-erlang 21.3.8.17
+elixir 1.7.4-otp-22
+erlang 22.2.8


### PR DESCRIPTION
OTP 21 can not be compiled on MacOS Catalina. The bug was only patched in OTP 22 https://bugs.erlang.org/browse/ERL-1205. No one using asfd on Catalina can build a release without changing this file.